### PR TITLE
Sync pico_sdk_import.cmake with upstream to fix PICO_SDK_FETCH_FROM_GIT

### DIFF
--- a/pico_sdk_import.cmake
+++ b/pico_sdk_import.cmake
@@ -3,8 +3,6 @@
 # This can be dropped into an external project to help locate this SDK
 # It should be include()ed prior to project()
 
-# todo document
-
 if (DEFINED ENV{PICO_SDK_PATH} AND (NOT PICO_SDK_PATH))
     set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
     message("Using PICO_SDK_PATH from environment ('${PICO_SDK_PATH}')")
@@ -20,8 +18,8 @@ if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_PATH} AND (NOT PICO_SDK_FETCH_FROM_GIT_P
     message("Using PICO_SDK_FETCH_FROM_GIT_PATH from environment ('${PICO_SDK_FETCH_FROM_GIT_PATH}')")
 endif ()
 
-set(PICO_SDK_PATH "${PICO_SDK_PATH}" CACHE PATH "Path to the PICO SDK")
-set(PICO_SDK_FETCH_FROM_GIT "${PICO_SDK_FETCH_FROM_GIT}" CACHE BOOL "Set to ON to fetch copy of PICO SDK from git if not otherwise locatable")
+set(PICO_SDK_PATH "${PICO_SDK_PATH}" CACHE PATH "Path to the Raspberry Pi Pico SDK")
+set(PICO_SDK_FETCH_FROM_GIT "${PICO_SDK_FETCH_FROM_GIT}" CACHE BOOL "Set to ON to fetch copy of SDK from git if not otherwise locatable")
 set(PICO_SDK_FETCH_FROM_GIT_PATH "${PICO_SDK_FETCH_FROM_GIT_PATH}" CACHE FILEPATH "location to download SDK")
 
 if (NOT PICO_SDK_PATH)
@@ -33,18 +31,18 @@ if (NOT PICO_SDK_PATH)
         endif ()
         FetchContent_Declare(
                 pico_sdk
-                GIT_REPOSITORY git@asic-git.pitowers.org:projectmu/pico_sdk.git
+                GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
                 GIT_TAG master
         )
         if (NOT pico_sdk)
-            message("Downloading PICO SDK")
+            message("Downloading Raspberry Pi Pico SDK")
             FetchContent_Populate(pico_sdk)
             set(PICO_SDK_PATH ${pico_sdk_SOURCE_DIR})
         endif ()
         set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})
     else ()
         message(FATAL_ERROR
-                "PICO SDK location was not specified. Please set PICO_SDK_PATH or set PICO_SDK_FETCH_FROM_GIT to on to fetch from git."
+                "SDK location was not specified. Please set PICO_SDK_PATH or set PICO_SDK_FETCH_FROM_GIT to on to fetch from git."
                 )
     endif ()
 endif ()
@@ -56,9 +54,9 @@ endif ()
 
 set(PICO_SDK_INIT_CMAKE_FILE ${PICO_SDK_PATH}/pico_sdk_init.cmake)
 if (NOT EXISTS ${PICO_SDK_INIT_CMAKE_FILE})
-    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' does not appear to contain the PICO SDK")
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' does not appear to contain the Raspberry Pi Pico SDK")
 endif ()
 
-set(PICO_SDK_PATH ${PICO_SDK_PATH} CACHE PATH "Path to the PICO SDK" FORCE)
+set(PICO_SDK_PATH ${PICO_SDK_PATH} CACHE PATH "Path to the Raspberry Pi Pico SDK" FORCE)
 
 include(${PICO_SDK_INIT_CMAKE_FILE})


### PR DESCRIPTION
Ran into this when I was setting up.   The fix for the issue is L34 but upstream had some other changes so I just included those.  